### PR TITLE
Add property to set YARN AM cpu cores

### DIFF
--- a/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
@@ -76,6 +76,12 @@ public class YarnConfig extends MapConfig {
   private static final int DEFAULT_AM_CONTAINER_MAX_MEMORY_MB = 1024;
 
   /**
+   * Number of CPU cores to request from YARN for running the AM
+   */
+  public static final String AM_CONTAINER_MAX_CPU_CORES = "yarn.am.container.cpu.cores";
+  private static final int DEFAULT_AM_CPU_CORES = 1;
+
+  /**
    * Determines the interval for the Heartbeat between the AM and the Yarn RM
    */
   public static final String AM_POLL_INTERVAL_MS = "yarn.am.poll.interval.ms";
@@ -168,6 +174,10 @@ public class YarnConfig extends MapConfig {
 
   public int getAMContainerMaxMemoryMb() {
     return getInt(AM_CONTAINER_MAX_MEMORY_MB, DEFAULT_AM_CONTAINER_MAX_MEMORY_MB);
+  }
+
+  public int getAMContainerMaxCpuCores() {
+    return getInt(AM_CONTAINER_MAX_CPU_CORES, DEFAULT_AM_CPU_CORES);
   }
 
   public String getAmOpts() {

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -92,7 +92,7 @@ class ClientHelper(conf: Configuration) extends Logging {
 
     val packagePath = new Path(yarnConfig.getPackagePath)
     val mem = yarnConfig.getAMContainerMaxMemoryMb
-    val cpu = 1
+    val cpu = yarnConfig.getAMContainerMaxCpuCores
     val queueName = Option(yarnConfig.getQueueName)
 
     // If we are asking for memory more than the max allowed, shout out


### PR DESCRIPTION
In some cases we need to set up CPU cores count for samza application masters. Previously, samza had hardcoded value = 1 for CPU​ cores. In this patch "yarn.am.container.cpu.cores" property has been added with default value 1.

This can be useful if we want to run AM on some specific nodes with specific CPU cores count.
