### PR TITLE
Add YARN Node label support

### DIFF
--- a/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
@@ -46,6 +46,11 @@ public class YarnConfig extends MapConfig {
   private static final int DEFAULT_CPU_CORES = 1;
 
   /**
+   * Label to request from YARN for containers
+   */
+  public static final String CONTAINER_LABEL = "yarn.container.label";
+
+  /**
    * Maximum number of times the AM tries to restart a failed container
    */
   public static final String CONTAINER_RETRY_COUNT = "yarn.container.retry.count";
@@ -74,6 +79,11 @@ public class YarnConfig extends MapConfig {
    */
   public static final String AM_CONTAINER_MAX_MEMORY_MB = "yarn.am.container.memory.mb";
   private static final int DEFAULT_AM_CONTAINER_MAX_MEMORY_MB = 1024;
+
+  /**
+   * Label to request from YARN for running the AM
+   */
+  public static final String AM_CONTAINER_LABEL = "yarn.am.container.label";
 
   /**
    * Determines the interval for the Heartbeat between the AM and the Yarn RM
@@ -154,6 +164,10 @@ public class YarnConfig extends MapConfig {
     return getInt(CONTAINER_MAX_CPU_CORES, DEFAULT_CPU_CORES);
   }
 
+  public String getContainerLabel() {
+    return get(CONTAINER_LABEL, null);
+  }
+
   public boolean getJmxServerEnabled() {
     return getBoolean(AM_JMX_ENABLED, true);
   }
@@ -168,6 +182,10 @@ public class YarnConfig extends MapConfig {
 
   public int getAMContainerMaxMemoryMb() {
     return getInt(AM_CONTAINER_MAX_MEMORY_MB, DEFAULT_AM_CONTAINER_MAX_MEMORY_MB);
+  }
+
+  public String getAMContainerLabel() {
+    return get(AM_CONTAINER_LABEL, null);
   }
 
   public String getAmOpts() {

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -184,6 +184,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
 
     int memoryMb = resourceRequest.getMemoryMB();
     int cpuCores = resourceRequest.getNumCores();
+    String containerLabel = yarnConfig.getContainerLabel();
     String preferredHost = resourceRequest.getPreferredHost();
     Resource capability = Resource.newInstance(memoryMb, cpuCores);
     Priority priority =  Priority.newInstance(DEFAULT_PRIORITY);
@@ -193,7 +194,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
     if (preferredHost.equals("ANY_HOST"))
     {
       log.info("Making a request for ANY_HOST " + preferredHost );
-      issuedRequest = new AMRMClient.ContainerRequest(capability, null, null, priority);
+      issuedRequest = new AMRMClient.ContainerRequest(capability, null, null, priority, true, containerLabel);
     }
     else
     {
@@ -202,7 +203,9 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
               capability,
               new String[]{preferredHost},
               null,
-              priority);
+              priority,
+              true,
+              containerLabel);
     }
     //ensure that updating the state and making the request are done atomically.
     synchronized (lock) {

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -94,6 +94,7 @@ class ClientHelper(conf: Configuration) extends Logging {
     val mem = yarnConfig.getAMContainerMaxMemoryMb
     val cpu = 1
     val queueName = Option(yarnConfig.getQueueName)
+    val appMasterLabel = Option(yarnConfig.getAMContainerLabel)
 
     // If we are asking for memory more than the max allowed, shout out
     if (mem > newAppResponse.getMaximumResourceCapability().getMemory()) {
@@ -121,6 +122,14 @@ class ClientHelper(conf: Configuration) extends Logging {
     name match {
       case Some(name) => { appCtx.setApplicationName(name) }
       case None => { appCtx.setApplicationName(appId.get.toString) }
+    }
+
+    appMasterLabel match {
+      case Some(label) => {
+        appCtx.setNodeLabelExpression(label)
+        info("set yarn node label expression to %s" format queueName)
+      }
+      case None =>
     }
 
     queueName match {


### PR DESCRIPTION
YARN Node labels were introduced in Hadoop version 2.6, which allows to group nodes with similar characteristics and allows applications to specify where to run. This patch adds support for YARN node labels in Samza.

In this implementation, node labels are defined directly in yarnConfig in YarnClusterResourceManager. It might be better to have node labels as a part of SamzaResourceRequest and SamzaResource classes, but org.apache.hadoop.yarn.api.records.Container class doesn't contain node label and hence we have nothing to pass to the SamzaResource constructor in onContainersAllocated method of YarnClusterResourceManager class.
